### PR TITLE
Treat setenv as shell commands rather than simple strings

### DIFF
--- a/hublib/use/__init__.py
+++ b/hublib/use/__init__.py
@@ -8,6 +8,7 @@ Works for all currently installed modules except two old ones that use local she
 
 import sys
 import os
+import subprocess
 from string import Template
 from IPython.core.magic import register_line_magic
 
@@ -18,7 +19,17 @@ d = {}
 def setenv(line):
     name = line[0]
     val = ' '.join(line[1:])
-    os.environ[name] = val
+    try:
+        completedProcess = subprocess.run("""/bin/bash -c 'echo %s'""" % (val),stdout=subprocess.PIPE,shell=True)
+    except:
+        pass
+    else:
+        if completedProcess.returncode == 0:
+            try:
+                os.environ[name] = completedProcess.stdout.strip().decode('utf-8')
+                _set(name, os.environ[name])
+            except:
+                pass
 
 def prepend(line):
     global d


### PR DESCRIPTION
The Python implementation of use is not as comprehensive as the shell implementation. 
The change was spurred by a requirement to set environment variables dependent in part on what host was being used.